### PR TITLE
feat: add demo link, update domain nav links

### DIFF
--- a/theme/main.html
+++ b/theme/main.html
@@ -1,8 +1,33 @@
 {% extends "base.html" %} {% block announce %}
 <div class="domain-nav-container">
-  <a href="https://www.dhis2.org" class="domain-nav-item">DHIS2.org</a>
-  <a href="https://community.dhis2.org" class="domain-nav-item">Community</a>
-  <a href="https://developers.dhis2.org" class="domain-nav-item">Developers</a>
+  <a
+    href="https://www.dhis2.org"
+    target="_blank"
+    rel="noopener"
+    class="domain-nav-item"
+    >DHIS2.org</a
+  >
+  <a
+    href="https://play.dhis2.org"
+    target="_blank"
+    rel="noopener"
+    class="domain-nav-item"
+    >Demo</a
+  >
+  <a
+    href="https://community.dhis2.org"
+    target="_blank"
+    rel="noopener"
+    class="domain-nav-item"
+    >Community</a
+  >
+  <a
+    href="https://developers.dhis2.org"
+    target="_blank"
+    rel="noopener"
+    class="domain-nav-item"
+    >Developers</a
+  >
 </div>
 {% endblock %} {% block content %}
 <div class="md-content-alternates">


### PR DESCRIPTION
This PR updates the domain navigation bar:
- add "Demo" link to be consistent with the domain nav on dhis2.org.
- changes links to open in new tabs, consistent with dhis2.org