### PR TITLE
Design fixes

### DIFF
--- a/theme/partials/search.html
+++ b/theme/partials/search.html
@@ -1,17 +1,33 @@
-{#-
-  This file was automatically generated - do not edit
--#}
-{% import "partials/language.html" as lang with context %}
+{#- This file was automatically generated - do not edit -#} {% import
+"partials/language.html" as lang with context %}
 <div class="md-search" data-md-component="search" role="dialog">
   <label class="md-search__overlay" for="__search"></label>
   <div class="md-search__inner" role="search">
     <form class="md-search__form" name="search">
-      <input type="text" class="md-search__input" name="query" aria-label="{{ lang.t('search.placeholder') }}" placeholder="{{ lang.t('search.placeholder') }}" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" data-md-component="search-query" data-md-state="active" required>
+      <input
+        type="text"
+        class="md-search__input"
+        name="query"
+        aria-label="{{ lang.t('search.placeholder') }}"
+        placeholder="{{ lang.t('search.placeholder') }}"
+        autocapitalize="off"
+        autocorrect="off"
+        autocomplete="off"
+        spellcheck="false"
+        data-md-component="search-query"
+        data-md-state="active"
+      />
       <label class="md-search__icon md-icon" for="__search">
-        {% include ".icons/material/magnify.svg" %}
-        {% include ".icons/material/arrow-left.svg" %}
+        {% include ".icons/material/magnify.svg" %} {% include
+        ".icons/material/arrow-left.svg" %}
       </label>
-      <button type="reset" class="md-search__icon md-icon" aria-label="{{ lang.t('search.reset') }}" data-md-component="search-reset" tabindex="-1">
+      <button
+        type="reset"
+        class="md-search__icon md-icon"
+        aria-label="{{ lang.t('search.reset') }}"
+        data-md-component="search-reset"
+        tabindex="-1"
+      >
         {% include ".icons/material/close.svg" %}
       </button>
     </form>

--- a/theme/resources/css/mkdocs_dhis2.css
+++ b/theme/resources/css/mkdocs_dhis2.css
@@ -245,12 +245,10 @@ pre {
   margin-left: 0.6rem;
   background-image: url('data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjUiIHZpZXdCb3g9IjAgMCA4IDUiIHdpZHRoPSI4IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Im0xMjEuNjQ2IDYuNjQ2LjcwOC43MDgtMy4zNTQgMy4zNTMtMy4zNTQtMy4zNTMuNzA4LS43MDggMi42NDYgMi42NDd6IiBmaWxsPSIjZmZmZmZmIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTE1IC02KSIvPjwvc3ZnPg==');
 }
-/* .md-header-nav select option {
-    margin: 40px;
-    background: rgb(0 0 0);
-    color: var(--md-primary-bg-color);
+/* style the select options to native on all platforms */
+select option {
+  color: var(--text-base);
 }
-*/
 .language-selector-wrap {
   align-self: center;
   display: flex;

--- a/theme/resources/css/mkdocs_dhis2.css
+++ b/theme/resources/css/mkdocs_dhis2.css
@@ -423,6 +423,12 @@ a.domain-nav-item:after {
 .md-typeset h3[id]:target::before,
 .md-typeset h2[id]:target::before,
 .md-typeset h1[id]:target::before {
+  margin-top: 0;
+  padding-top: 100px;
+}
+.md-typeset h3[id]::before,
+.md-typeset h2[id]::before,
+.md-typeset h1[id]::before {
   margin-top: -4.5rem;
   padding-top: 4.5rem;
 }


### PR DESCRIPTION
This PR fixes several small issues:
- fixes the unreadable `<option>` text color on non-OSX browsers
- adjusts the spacing on headers to make the table of contents active states more accurate
- removes "Please fill in this field" tooltip from search field ([Material MKdocs commit](https://github.com/squidfunk/mkdocs-material/commit/035225d6d3a90985310504bc4836c3869914b4ea))