### PR TITLE
chore(deps): simplify dep management across dev environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This is the build source for the DHIS2 documentation site.
 
 ### Requirements and setup
 
-Python3 is required (tested with python 3.8)
+- Python3 is required (tested with python 3.7, 3.8, 3.9)
+- Pango 1.x (debian: `libpango1.0.0`)
+- Cairo (debian: `python3-cairo`)
 
 Setup the environment
 ```

--- a/scripts/setup-deps.sh
+++ b/scripts/setup-deps.sh
@@ -1,0 +1,13 @@
+pip3 install -r requirements.txt
+
+cd tools/python/markdown-pp-master
+pip3 install -e .
+cd -
+
+cd tools/python/markdown-extensions/d_card
+pip3 install -e .
+cd -
+
+cd tools/python/dhis2_plugins
+pip3 install -e .
+cd -

--- a/scripts/setup-deps.sh
+++ b/scripts/setup-deps.sh
@@ -1,13 +1,7 @@
+# install dependencies
 pip3 install -r requirements.txt
 
-cd tools/python/markdown-pp-master
-pip3 install -e .
-cd -
-
-cd tools/python/markdown-extensions/d_card
-pip3 install -e .
-cd -
-
-cd tools/python/dhis2_plugins
-pip3 install -e .
-cd -
+# install custom plugins
+pip3 install -e tools/python/markdown-pp-master
+pip3 install -e tools/python/markdown-extensions/d_card
+pip3 install -e tools/python/dhis2_plugins

--- a/setup_venv
+++ b/setup_venv
@@ -7,22 +7,8 @@
 python3 -m venv venv
 
 source venv/bin/activate
-pip install -r requirements.txt
 
-cd tools/python/markdown-pp-master
-python3 setup.py develop
-pip install MarkdownPP
-cd -
-
-cd tools/python/markdown-extensions/d_card
-python3 setup.py develop
-pip install d_card
-cd -
-
-cd tools/python/dhis2_plugins
-python3 setup.py develop
-pip install dhis2_plugins
-cd -
+source scripts/setup-deps.sh
 
 # a temporary hacks
 cp tools/python/blockprocessors.py venv/lib/python3*/site-packages/markdown/


### PR DESCRIPTION
Make it easier to manage dependencies across multiple dev environments,
while maintaining the original setup_venv script functionality.

Dependency installation and setup is extracted to scripts/setup-deps.sh,
and the setup_venv script has been refactored to use it. This split
allows us to use venv, virtualenv, or Docker with the docs-builder.

Instead of using setuputils, we use pip to install the local plugins in
development mode (safer alternative to 'setup.py develop') which is
equivalent but is able to manage the dependencies with pip.

Calls to the 'pip' binary has been replaced with 'pip3' to ensure that
we use a python3 compatible pip version.

"Temporary hacks" may not be necessary when using pip3 to install the
deps, but has been maintained because I cannot verify this locally on
account of not being able to use venv.

Finally the README has been updated with additional prerequisites for
docs-builder to work (cairo and pango).
