### PR TITLE
fix: use prettier to remove wrapping on paragraphs

### DIFF
--- a/.github/workflows/english.yml
+++ b/.github/workflows/english.yml
@@ -49,6 +49,12 @@ jobs:
         cp tools/python/attr_list.py ${pythonLocation}/lib/python3.8/site-packages/markdown/extensions/
         cp tools/python/tables.py ${pythonLocation}/lib/python3.8/site-packages/markdown/extensions/
 
+    - name:
+      uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      run: npm install -g prettier
+
     - name: Build the docs
       run: |
         mkdocs build

--- a/.github/workflows/english_full.yml
+++ b/.github/workflows/english_full.yml
@@ -49,6 +49,12 @@ jobs:
         cp tools/python/attr_list.py ${pythonLocation}/lib/python3.8/site-packages/markdown/extensions/
         cp tools/python/tables.py ${pythonLocation}/lib/python3.8/site-packages/markdown/extensions/
 
+    - name:
+      uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      run: npm install -g prettier
+
     - name: Build the docs
       run: |
         mkdocs build --config-file mkdocs_single_page.yml

--- a/tools/python/dhis2_plugins/dhis2_docs/plugin.py
+++ b/tools/python/dhis2_plugins/dhis2_docs/plugin.py
@@ -55,7 +55,19 @@ class Dhis2DocsPlugin(BasePlugin):
 
         # Push English source files to transifex
         if lang == 'en':
-            fetcher.push_translations()
+            # run prettier over the markdown to remove line wrapping (ensures consistent
+            # formatting for transifex)
+            try:
+                print("Formatting files with prettier and removing line wrapping...")
+                prettify = subprocess.Popen(['prettier', '--prose-wrap', 'never', '--write', 'docs/**/*.md'])
+                prettify.wait()
+                print("Done.")
+
+                # Only attempt to push sources to transifex if the files are successfully formatted
+                fetcher.push_translations()
+
+            except OSError:
+                print("prettier not found. Markdown files may render differently in the official build.")
 
         # Pull translated versions of files from transifex if necessary
         if lang != 'en':


### PR DESCRIPTION
This is required to avoid the impact of carriage returns in the 
transifex workflow
(carriage returns are considered part of the string by transifex).

This should skip over gracefully for local builds if prettier is not 
available.