### PR TITLE
docs: add personal access tokens page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -332,6 +332,7 @@ nav:
             Working with your account:
               - Messaging: '@github(dhis2/dhis2-docs, src/user/messaging.md,2.37)'
               - '@github(dhis2/user-profile-app, docs/user/index.yml, master)'
+              - Personal access tokens: '@github(dhis2/dhis2-docs, src/user/personal-access-tokens.md,master)'
             Configuring the system:
               - Metadata: '@github(dhis2/dhis2-docs, src/user/configure-metadata.md,2.37)'
               - Programs: '@github(dhis2/dhis2-docs, src/user/configure-programs-in-the-maintenance-app.md,2.37)'


### PR DESCRIPTION
Blocked by https://github.com/dhis2/dhis2-docs/pull/882

Adds documentation for personal access tokens to the 'Working with you account' section.