### PR TITLE
docs: reference collocated docs from capture-app repo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -279,7 +279,7 @@ nav:
               - Data Entry: '@github(dhis2/dhis2-docs, src/user/using-the-data-entry-app.md,master)'
               - Data Quality: '@github(dhis2/dhis2-docs, src/user/control-data-quality.md,master)'
             Tracking individual level data:
-              - Capture: '@github(dhis2/dhis2-docs, src/user/using-the-capture-app.md,master)'
+              - '@github(dhis2/capture-app, docs/user/index.yml, master)'
               - Event Capture: '@github(dhis2/dhis2-docs, src/user/using-the-event-capture-app.md,master)'
               - Tracker Capture: '@github(dhis2/dhis2-docs, src/user/using-the-tracker-capture-app.md,master)'
             Approving data:

--- a/mkdocs_single_page.yml
+++ b/mkdocs_single_page.yml
@@ -117,7 +117,7 @@ nav:
               - '@github(dhis2/dhis2-docs, src/user/what-is-dhis2.md,master)'
               - '@github(dhis2/dhis2-docs, src/user/using-the-data-entry-app.md,master)'
               - '@github(dhis2/dhis2-docs, src/user/control-data-quality.md,master)'
-              - '@github(dhis2/dhis2-docs, src/user/using-the-capture-app.md,master)'
+              - '@github(dhis2/capture-app, docs/user/using-the-capture-app.md, master)'
               - '@github(dhis2/dhis2-docs, src/user/using-the-event-capture-app.md,master)'
               - '@github(dhis2/dhis2-docs, src/user/using-the-tracker-capture-app.md,master)'
               - '@github(dhis2/dhis2-docs, src/user/data-approval.md,master)'
@@ -159,7 +159,7 @@ nav:
             DHIS2 End User Manual:
               - '@github(dhis2/dhis2-docs, src/user/what-is-dhis2.md,master)'
               - '@github(dhis2/dhis2-docs, src/user/using-the-data-entry-app.md,master)'
-              - '@github(dhis2/dhis2-docs, src/user/using-the-capture-app.md,master)'
+              - '@github(dhis2/capture-app, docs/user/using-the-capture-app.md, master)'
               - '@github(dhis2/dhis2-docs, src/user/using-the-event-capture-app.md,master)'
               - '@github(dhis2/dhis2-docs, src/user/using-the-tracker-capture-app.md,master)'
               - '@github(dhis2/dhis2-docs, src/user/data-approval.md,master)'


### PR DESCRIPTION
Docs for the Capture app is being moved to the capture-app repo.
