### PR TITLE
fix: latest pyments is not compatible with mkdocs-material version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,12 @@ cssselect2==0.2.1
 gitdb==4.0.5
 GitPython==3.1.11
 defusedxml==0.5.0
-html5lib==1.0.1
 idna==2.8
 Jinja2==3.0.3
 Markdown==3.2.1
 markdown-captions==2
 mkdocs==1.2.3
+pygments==2.11.2
 mkdocs-material==7.3.4
 mkdocs-minify-plugin==0.2.1
 pdfrw==0.4


### PR DESCRIPTION
lock pygments version to 2.11.2 until mkdocs-material is next updated.