### PR TITLE
feat: link to index pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ theme:
     - navigation.tabs.sticky
     - navigation.top
     - navigation.instant
+    - navigation.indexes
     - toc.integration
     - content.action.edit
     - content.code.copy

--- a/mkdocs_designlab.yml
+++ b/mkdocs_designlab.yml
@@ -32,6 +32,7 @@ theme:
   features:
     - navigation.tabs
     - navigation.top
+    - navigation.indexes
     - toc.integration
   alternates:
     alt_marker: 'alt__'

--- a/theme/partials/nav-item.html
+++ b/theme/partials/nav-item.html
@@ -77,7 +77,7 @@
       {% set indexes = [] %}
       {% if "navigation.indexes" in features %}
         {% for nav_item in nav_item.children %}
-          {% if nav_item.is_index and not index is defined %}
+          {% if (nav_item.is_index or nav_item.title=="OVERVIEW") and not index is defined %}
             {% set _ = indexes.append(nav_item) %}
           {% endif %}
         {% endfor %}

--- a/theme/resources/css/mkdocs_dhis2.css
+++ b/theme/resources/css/mkdocs_dhis2.css
@@ -512,6 +512,11 @@ a.domain-nav-item:after {
   cursor:default;
   font-weight:600;
 }
+
+.md-nav__link--index a:hover,
+a.md-nav__link:hover{
+  text-decoration:underline;
+}
 /* adjust the padding for link-to-headers to account for the new alternate bar */
 .md-typeset h3[id]:target::before,
 .md-typeset h2[id]:target::before,

--- a/theme/resources/css/mkdocs_dhis2.css
+++ b/theme/resources/css/mkdocs_dhis2.css
@@ -134,7 +134,7 @@
 }
 */
 
-.md-banner__inner 
+.md-banner__inner
 {
 margin:0 !important;
 padding:0 !important;
@@ -508,6 +508,10 @@ a.domain-nav-item:after {
   color: var(--action-hover);
 }
 
+.md-nav__link--index a {
+  cursor:default;
+  font-weight:600;
+}
 /* adjust the padding for link-to-headers to account for the new alternate bar */
 .md-typeset h3[id]:target::before,
 .md-typeset h2[id]:target::before,
@@ -1029,12 +1033,12 @@ v-tag mark {
   align-items: center;
   padding: 2px 12px;
   gap: 5px;
-  
+
   height: 23px;
   color:var(--grey900);
-  
+
   /* grey/grey200 */
-  
+
   background: var(--grey200);
   border:1px solid  var(--grey400);
   border-radius: 10px;


### PR DESCRIPTION
index.md or overview.md pages should now be linked from the parent nav item.
This is quite subtle in this first implementation - the cursor should show an arrow when hovering the "overview" parent items, instead of a hand pointer. It is still possible to expand/contract the child items without clicking the link, by clicking only the expand icon.