### PR TITLE
docs: users should land on new tracker by default

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -712,7 +712,7 @@ nav:
             - Users: '@github(dhis2/dhis2-docs, src/developer/web-api/users.md, master)'
             - Settings and configuration: '@github(dhis2/dhis2-docs, src/developer/web-api/settings-and-configuration.md, master)'
             - Tracker: '@github(dhis2/dhis2-docs, src/developer/web-api/tracker.md, master)'
-            - New Tracker: '@github(dhis2/dhis2-docs, src/developer/web-api/new-tracker.md, master)'
+            - Tracker (deprecated): '@github(dhis2/dhis2-docs, src/developer/web-api/tracker-old.md, master)'
             - Email: '@github(dhis2/dhis2-docs, src/developer/web-api/email.md, master)'
             - Data Store: '@github(dhis2/dhis2-docs, src/developer/web-api/data-store.md, master)'
             - Data Entry: '@github(dhis2/dhis2-docs, src/developer/web-api/data-entry.md, master)'

--- a/mkdocs_single_page.yml
+++ b/mkdocs_single_page.yml
@@ -441,7 +441,7 @@ nav:
             - '@github(dhis2/dhis2-docs, src/developer/web-api/users.md, master)'
             - '@github(dhis2/dhis2-docs, src/developer/web-api/settings-and-configuration.md, master)'
             - '@github(dhis2/dhis2-docs, src/developer/web-api/tracker.md, master)'
-            - '@github(dhis2/dhis2-docs, src/developer/web-api/new-tracker.md, master)'
+            - '@github(dhis2/dhis2-docs, src/developer/web-api/tracker-old.md, master)'
             - '@github(dhis2/dhis2-docs, src/developer/web-api/email.md, master)'
             - '@github(dhis2/dhis2-docs, src/developer/web-api/data-store.md, master)'
             - '@github(dhis2/dhis2-docs, src/developer/web-api/organisation-unit-profile.md, master)'


### PR DESCRIPTION
following changes in https://github.com/dhis2/dhis2-docs/pull/1157

its been at least 2 years since new tracker has been released (from 2.36 according to our docs). New tracker is far from new anymore. We've added a disclaimer to the old tracker docs some time ago that anyone starting out should use the new tracker APIs. Its time to also rearrange the pages so new users land on the new tracker APIs by default.

This is how the pages should show up in the sidebar on the left

- Tracker
- Tracker (deprecated)

I've used the word old as its the one we are using internally and its the antonym for new. Let me know if you another name makes more sense 👌🏻